### PR TITLE
Remove using and pipe

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,5 @@
 import Config
 
-if File.exists? "#{Mix.env()}.exs" do
+if File.exists? "config/#{Mix.env()}.exs" do
   import_config "#{Mix.env()}.exs"
 end

--- a/guides/honeybee/introduction.md
+++ b/guides/honeybee/introduction.md
@@ -23,6 +23,7 @@ while still being useful to developers.
 The core concept of Honeybee is the pipeline.
 Pipelines can be declared, reused and composed to avoid code repetition.
 Each request defines a unique request pipeline.
+Much of the DSL leverages techniques, concepts and styles from the `Plug` library.
 
 ### Strict compile-time validations
 Honeybee will provide strict validation during compilation,

--- a/guides/honeybee/routing.md
+++ b/guides/honeybee/routing.md
@@ -118,11 +118,7 @@ Plug has a pluggable module which can be added to the request pipeline in order 
 defmodule MyApp.MyApi.MyRouter do
   use Honeybee
 
-  pipe :body_parser do
-    plug Plug.Parsers, parsers: [:json], pass: ["application/json"], json_decoder: Poison
-  end
-
-  using :body_parser
+  plug Plug.Parsers, parsers: [:json], pass: ["application/json"], json_decoder: Poison
 
   match _, "/knock/knock", do: plug MyApp.MyApi.MyFirstRouteHandler, handler: :hello_world
 
@@ -139,18 +135,10 @@ In this example we will add a scope which validates requests on all routes.
 defmodule MyApp.MyApi.MyRouter do
   use Honeybee
 
-  pipe :body_parser do
-    plug Plug.Parsers, parsers: [:json], pass: ["application/json"], json_decoder: Poison
-  end
-
-  pipe :authorization do
-    plug Authorization, level: :admin
-  end
-
-  using :body_parser
+  plug Plug.Parsers, parsers: [:json], pass: ["application/json"], json_decoder: Poison
 
   scope do
-    using :authorization
+    plug Authorization, level: :admin
 
     get "/users", do: plug MyApp.MyApi.MyFirstRouteHandler, handler: :get_users
   end
@@ -170,18 +158,10 @@ This can be seen below in the `"knock/knock"` route.
 defmodule MyApp.MyApi.MyRouter do
   use Honeybee
 
-  pipe :body_parser do
-    plug Plug.Parsers, parsers: [:json], pass: ["application/json"], json_decoder: Poison
-  end
-
-  pipe :authorization do
-    plug Authorization, level: :admin
-  end
-
-  using :body_parser
+  plug Plug.Parsers, parsers: [:json], pass: ["application/json"], json_decoder: Poison
 
   scope do
-    using :authorization
+    plug Authorization, level: :admin
 
     get "/users", do: plug MyApp.MyApi.MyFirstRouteHandler, handler: :get_users
   end
@@ -206,22 +186,14 @@ Below is an example of forwarding in a Honeybee router.
 defmodule MyApp.MyApi.MyRouter do
   use Honeybee
 
-  pipe :body_parser do
-    plug Plug.Parsers, parsers: [:json], pass: ["application/json"], json_decoder: Poison
-  end
-
-  pipe :authorization do
-    plug Authorization, level: :admin
-  end
-
   match _, "/forward/*forward_path" do
     plug MySecondRouter, forward_with: "forward_path"
   end
 
-  using :body_parser
+  plug Plug.Parsers, parsers: [:json], pass: ["application/json"], json_decoder: Poison
 
   scope do
-    using :authorization
+    plug Authorization, level: :admin
 
     get "/users", do: plug MyApp.MyApi.MyFirstRouteHandler, handler: :get_users
   end

--- a/test/scope.exs
+++ b/test/scope.exs
@@ -18,18 +18,14 @@ defmodule Honeybee.Test.Scope do
     def test1(conn, _opts), do: Plug.Conn.put_private(conn, :test1, :test1)
     def test2(conn, _opts), do: Plug.Conn.put_private(conn, :test2, :test2)
 
-    pipe :test_global, do: plug :test_global
-    pipe :test1, do: plug :test1
-    pipe :test2, do: plug :test2
-
-    using :test_global
+    plug :test_global
     scope do
-      using :test1
+      plug :test1
       get "/test1", do: plug Routes, :ok
     end
 
     scope "/test1" do
-      using :test2
+      plug :test2
       get "/test2", do: plug Routes, :ok
       
       scope "/test2" do


### PR DESCRIPTION
Removed the macros using and pipe, replacing it with plug and
composition. It was confusing to have so many different ways of
invoking plug pipelines, it is now consolidated to only the plug
macro.

Compositions do what the pipe used to do, and can be invoked
using the plug macro. Compositions also allow for option
manipulation, making it more versatile than pipe.